### PR TITLE
[GPT-70] Evaluate i18n per field

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-module.exports = function(grunt) {
+module.exports = function (grunt) {
     'use strict';
 
     // Project configuration.
@@ -13,12 +13,17 @@ module.exports = function(grunt) {
                 jshintrc: '.jshintrc'
             }
         },
-        mochaTest:{
+        mochaTest: {
             options: {
                 reporter: 'spec'
             },
-            tests:{
+            tests: {
                 src: ['tests/tests.js']
+            }
+        },
+        mocha_istanbul: {
+            coverage: {
+                src: 'tests', // a folder works nicely
             }
         }
     });
@@ -26,6 +31,8 @@ module.exports = function(grunt) {
     // These plugins provide necessary tasks.
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-mocha-test');
+    grunt.loadNpmTasks('grunt-mocha-istanbul');
     grunt.registerTask('test', ['jshint', 'mochaTest']);
+    grunt.registerTask('coverage', ['mocha_istanbul']);
     grunt.registerTask('default', ['test']);
 };

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#i18n-transform
+# i18n-transform
 [![Build Status](https://travis-ci.org/opentable/i18n-transform.png?branch=master)](https://travis-ci.org/opentable/i18n-transform) [![NPM version](https://badge.fury.io/js/i18n-transform.png)](http://badge.fury.io/js/i18n-transform) ![Dependencies](https://david-dm.org/opentable/i18n-transform.png)
 ---
 
@@ -49,17 +49,69 @@ There is no return value from this method.
 
 If language selection fails (no matching languages), the callback will contain an error.
 
+
+#### `.transformByField({source}, [languages], {fields});`
+
+This method applies the transform on a field by field basis as opposed to comparing a whole `i18n`
+block like the `transform` method does.
+
+The `fields` object should adhere to the following schema:
+
+```
+{
+    "required": [
+        "Name",
+        "Address"
+    ],
+
+    "optional": [
+        "Description",
+        "DressCode"
+    ]
+}
+```
+
+For `required` fields, if a language match fails, the field from the primary language will be used. `Optional` fields
+will only be returned if a language is explicitly matched.
+
+The return value is different from `transform` as it returns the following schema:
+
+```
+{
+    "translations": {
+        "Name": "The Fat Duck",
+        "DressCode": "Salle à manger formelle"
+    },
+    "localization": {
+        "Name": "en-GB" // ISO 639-1 code
+        "DressCode": "fr-FR" // ISO 639-1 code
+    }
+}
+```
+
+- This method will only return values that are specified within the `fields`.
+
+- If the same field appears in both `required` and `optional` then the `required` value takes precedent.
+
+#### `.transformByFieldDestination({source}, [languages], {fields}, callback function(err));`
+
+This method does the same as the above, but it transforms the destination object with the `translations` & `localization` fields.
+
+There is no return value from this method.
+
+If language selection fails (no matching languages), the callback will contain an error.
+
 ##### Note
 
-This module is designed to work with the [accept-language-parser](https://github.com/andyroyle/accept-language-parser).
+This module is designed to work with the [accept-language-parser](https://github.com/opentable/accept-language-parser).
 
 ### Installation:
 
 ```
-npm install i18n-transform
+npm install --save i18n-transform
 ```
 
-### Usage:
+### Usage (transform) :
 
 ```
 var transformer = require("i18n-transform");
@@ -102,8 +154,6 @@ var result = transformer.transform(
         }
     ]
 );
-
-console.dir(result);
 ```
 
 output:
@@ -119,5 +169,75 @@ output:
       "region": "GB"
     },
     "gb-specific-field": "some en-GB value"
+}
+```
+### Usage (transformByField) :
+
+```
+var transformer = require("i18n-transform");
+
+var result = transformer.transformByField(
+    {
+        "id": 123,
+        "someinvariantfield": 45.45,
+        "i18n": [
+            {
+                "name": "the thing",
+                "somelocalisedfield": "local value",
+                "language": {
+                    "code": "en",
+                    "region": "GB"
+                },
+                "gb-specific-field": "some en-GB value"
+            },
+            {
+                "name": "the thang",
+                "somelocalisedfield": "local value 2",
+                "language": {
+                    "code": "en",
+                    "region": "US"
+                },
+                "us-specific-field": "some en-US value"
+            }
+        ]
+    },
+    [
+        {
+            "code": "en",
+            "region": "GB",
+            "quality": 1.0
+        },
+        {
+            "code": "en",
+            "region": "US",
+            "quality": 0.8
+        }
+    ],
+    {
+        "required":{
+            "name",
+            "somelocalisedfield",
+        },
+        "optional":{
+            "us-specific-field"
+        }
+    }
+);
+```
+
+output:
+
+```
+{
+    "translations": {
+        "name": "the thing",
+        "somelocalisedfield": "local value",
+        "us-specific-field": "some en-US value"
+    },
+    "localization":{
+        "name": "en-GB",
+        "somelocalisedfield": "en-GB",
+        "us-specific-field": "en-US"
+    }
 }
 ```

--- a/lib/i18n-transform.js
+++ b/lib/i18n-transform.js
@@ -1,4 +1,4 @@
-var hoek = require("hoek");
+var _ = require("lodash");
 
 var _getLanguageFromI18n = function (i18nObj) {
     if (i18nObj.Language) {
@@ -92,7 +92,7 @@ var _getLanguageFromI18n = function (i18nObj) {
         if (!language) {
             return destination;
         }
-        return hoek.merge(destination, language);
+        return _.assign(destination, language);
     },
 
     _getSelectedLanguage = function (source, i18nArray, languages) {

--- a/lib/i18n-transform.js
+++ b/lib/i18n-transform.js
@@ -28,7 +28,7 @@ var _getLanguageFromI18n = function (i18nObj) {
         return null;
     },
 
-    _isWildcard = function(language) {
+    _isWildcard = function (language) {
         return language.code === "*";
     },
 
@@ -51,7 +51,7 @@ var _getLanguageFromI18n = function (i18nObj) {
         var i18nLanguage = _getLanguageFromI18n(i18n);
 
         if (primaryLanguageCode) {
-            if(_isWildcard(language)) {
+            if (_isWildcard(language)) {
                 return primaryLanguageCode.toUpperCase() === i18nLanguage.ietf.toUpperCase();
             } else {
                 return !language.region && primaryLanguageCode.split('-')[0] === language.code;
@@ -115,9 +115,13 @@ var _getLanguageFromI18n = function (i18nObj) {
                 }
             });
 
-            if (required && !results.translations[field]) {
-                results.translations[field] = primaryTranslations[field];
-                results.localization[field] = primaryTranslations.Language.IETF;
+            if (!results.translations[field]) {
+                if (required) {
+                    results.translations[field] = primaryTranslations[field];
+                    results.localization[field] = primaryTranslations.Language.IETF;
+                } else {
+                    results.translations[field] = null;
+                }
             }
 
         });

--- a/lib/i18n-transform.js
+++ b/lib/i18n-transform.js
@@ -28,8 +28,41 @@ var _getLanguageFromI18n = function (i18nObj) {
         return null;
     },
 
-    _extractPrimaryLanguage = function (r, i18nArray) {
-        if (!r.PrimaryLanguage) {
+    _isWildcard = function(language) {
+        return language.code === "*";
+    },
+
+    _isLanguageCodeMatch = function (i18nLanguage, language) {
+        return language.code.toUpperCase() === i18nLanguage.code.toUpperCase();
+    },
+
+    _isLanguageRegionMatch = function (i18nLanguage, language) {
+        return (language.region === undefined || i18nLanguage.region === undefined) ||
+            language.region.toUpperCase() === i18nLanguage.region.toUpperCase();
+    },
+
+    _isLanguageMatch = function (i18n, language) {
+        var i18nLanguage = _getLanguageFromI18n(i18n);
+
+        return _isLanguageCodeMatch(i18nLanguage, language) && _isLanguageRegionMatch(i18nLanguage, language);
+    },
+
+    _isPrimaryLanguageMatch = function (i18n, language, primaryLanguageCode) {
+        var i18nLanguage = _getLanguageFromI18n(i18n);
+
+        if (primaryLanguageCode) {
+            if(_isWildcard(language)) {
+                return primaryLanguageCode.toUpperCase() === i18nLanguage.ietf.toUpperCase();
+            } else {
+                return !language.region && primaryLanguageCode.split('-')[0] === language.code;
+            }
+        }
+
+        return _isWildcard(language);
+    },
+
+    _extractPrimaryLanguage = function (source, i18nArray) {
+        if (!source.PrimaryLanguage) {
             //just use whatever is available
             if (i18nArray[0]) {
                 return i18nArray[0];
@@ -40,11 +73,11 @@ var _getLanguageFromI18n = function (i18nObj) {
 
         var language = null;
 
-        i18nArray.forEach(function (l) {
-            var i18nLanguage = _getLanguageFromI18n(l);
+        i18nArray.forEach(function (i18n) {
+            var i18nLanguage = _getLanguageFromI18n(i18n);
             if (i18nLanguage && i18nLanguage.ietf) {
-                if (i18nLanguage.ietf.toUpperCase() === r.PrimaryLanguage.toUpperCase()) {
-                    language = l;
+                if (i18nLanguage.ietf.toUpperCase() === source.PrimaryLanguage.toUpperCase()) {
+                    language = i18n;
                 }
             }
         });
@@ -52,40 +85,88 @@ var _getLanguageFromI18n = function (i18nObj) {
         return language;
     },
 
-    _shouldUsePrimaryLanguage = function (primaryLanguage, languageCode) {
-        return primaryLanguage &&
-            !languageCode.region &&
-            primaryLanguage.split('-')[0] === languageCode.code;
-    },
-
-    _extractPreferredLanguage = function (r, i18nArray, languages) {
-        var language = null;
-
-        languages.forEach(function (l) {
-            i18nArray.forEach(function (rl) {
-                var i18nLanguage = _getLanguageFromI18n(rl);
-
-                if (l.code === "*") {
-                    language = language || l.code;
-                }
-
-                if (_shouldUsePrimaryLanguage(r.PrimaryLanguage, l)) {
-                    language = language || "*";
-                }
-
-                if (l.code.toUpperCase() === i18nLanguage.code.toUpperCase() &&
-                    ((l.region === undefined || i18nLanguage.region === undefined) ||
-                        l.region.toUpperCase() === i18nLanguage.region.toUpperCase())) {
-                    language = language || rl;
-                }
+    _mapAcceptLanguagesToTranslations = function (acceptedLanguages, i18nArray, primaryLanguageCode) {
+        var results = _.map(acceptedLanguages, function (language) {
+            return _.find(i18nArray, function (i18n) {
+                return _isPrimaryLanguageMatch(i18n, language, primaryLanguageCode) ||
+                    _isLanguageMatch(i18n, language, primaryLanguageCode);
             });
         });
 
-        if (language === "*") {
-            return _extractPrimaryLanguage(r, i18nArray);
+        return _.omitBy(results, _.isUndefined);
+    },
+
+    _extractPerField = function (fields, acceptedLanguages, i18nArray, primaryTranslations, required) {
+        var results = {
+            translations: {},
+            localization: {}
+        };
+
+        var primaryLanguageCode = _getLanguageFromI18n(primaryTranslations).ietf;
+        var mappedTranslations = _mapAcceptLanguagesToTranslations(acceptedLanguages, i18nArray, primaryLanguageCode);
+
+        _.each(fields, function (field) {
+            _.each(mappedTranslations, function (translations) {
+
+                if (!_.isUndefined(translations[field])) {
+                    results.translations[field] = translations[field];
+                    results.localization[field] = translations.Language.IETF;
+                    return false;
+                }
+            });
+
+            if (required && !results.translations[field]) {
+                results.translations[field] = primaryTranslations[field];
+                results.localization[field] = primaryTranslations.Language.IETF;
+            }
+
+        });
+
+        return results;
+    },
+
+    _extractPreferredLanguagePerField = function (source, i18nArray, acceptedLanguages, fields) {
+        var translations = {};
+        var primaryTranslations = _extractPrimaryLanguage(source, i18nArray);
+
+        if (fields.required) {
+            _.merge(translations, _extractPerField(fields.required, acceptedLanguages,
+                i18nArray,
+                primaryTranslations,
+                true));
         }
 
-        return language;
+        if (fields.optional) {
+            _.merge(translations, _extractPerField(fields.optional, acceptedLanguages,
+                i18nArray,
+                primaryTranslations,
+                false));
+        }
+
+        return translations;
+    },
+
+    _extractPreferredLanguage = function (source, i18nArray, acceptedLanguages) {
+        var result = null;
+
+        _.each(acceptedLanguages, function (language) {
+            _.each(i18nArray, function (i18n) {
+                if (_isPrimaryLanguageMatch(i18n, language, source.PrimaryLanguage)) {
+                    result = _extractPrimaryLanguage(source, i18nArray);
+                    return false;
+                }
+
+                if (_isLanguageMatch(i18n, language)) {
+                    result = i18n;
+                    return false;
+                }
+            });
+
+            return !result;
+
+        });
+
+        return result;
     },
 
     _mergeSelectedLanguage = function (destination, language) {
@@ -95,61 +176,78 @@ var _getLanguageFromI18n = function (i18nObj) {
         return _.assign(destination, language);
     },
 
-    _getSelectedLanguage = function (source, i18nArray, languages) {
+    _getSelectedLanguage = function (source, i18nArray, acceptedLanguages, fields) {
         // expects the language object from the request to be passed in:
         // [
         //   { code: 'en', region: 'US', quality: 1.0 },
         //   { code: 'en',               quality: 0.8 },
         //    ...
         // ]
-        if (!languages || languages.length === 0) {
+        if (!acceptedLanguages || acceptedLanguages.length === 0) {
             return _extractPrimaryLanguage(source, i18nArray);
         }
         else {
-            languages.sort(function (a, b) {
+            acceptedLanguages.sort(function (a, b) {
                 return b.quality - a.quality;
             });
 
-            return _extractPreferredLanguage(source, i18nArray, languages);
+            return fields ? _extractPreferredLanguagePerField(source, i18nArray, acceptedLanguages, fields)
+                : _extractPreferredLanguage(source, i18nArray, acceptedLanguages);
+        }
+    },
+
+    _transform = function (source, acceptedLanguages, fields) {
+        var i18nInfo = _getI18n(source);
+
+        if (!i18nInfo) {
+            return source;
+        }
+
+        var selectedLanguage = _getSelectedLanguage(source, i18nInfo.value, acceptedLanguages, fields);
+        if (!selectedLanguage) {
+            return;
+        }
+
+        var result = _mergeSelectedLanguage(source, selectedLanguage);
+        delete result[i18nInfo.name];
+        return result;
+    },
+
+    _transformDestination = function (source, destinationToAddLanguageTo, acceptedLanguages, fields, callback) {
+        var i18nInfo = _getI18n(source);
+
+        if (!i18nInfo) {
+            return source;
+        }
+
+        var selectedLanguage = _getSelectedLanguage(source, i18nInfo.value, acceptedLanguages, fields);
+
+        if (!selectedLanguage) {
+            if (callback) {
+                callback(new Error("Could not find desired language: " + JSON.stringify(acceptedLanguages)));
+            }
+            return;
+        }
+
+        _mergeSelectedLanguage(destinationToAddLanguageTo, selectedLanguage);
+
+        if (callback) {
+            callback();
         }
     };
 
-module.exports.transform = function (source, languages) {
-    var i18nInfo = _getI18n(source);
-
-    if (!i18nInfo) {
-        return source;
-    }
-
-    var selectedLanguage = _getSelectedLanguage(source, i18nInfo.value, languages);
-    if (!selectedLanguage) {
-        return;
-    }
-
-    var result = _mergeSelectedLanguage(source, selectedLanguage);
-    delete result[i18nInfo.name];
-    return result;
+module.exports.transformByField = function (source, acceptedLanguages, fields) {
+    return _transform(source, acceptedLanguages, fields);
 };
 
-module.exports.transformDestination = function (source, destinationToAddLanguageTo, languages, callback) {
-    var i18nInfo = _getI18n(source);
+module.exports.transform = function (source, acceptedLanguages) {
+    return _transform(source, acceptedLanguages);
+};
 
-    if (!i18nInfo) {
-        return source;
-    }
+module.exports.transformByFieldDestination = function (source, destinationToAddLanguageTo, acceptedLanguages, fields, callback) {
+    return _transformDestination(source, destinationToAddLanguageTo, acceptedLanguages, fields, callback);
+};
 
-    var selectedLanguage = _getSelectedLanguage(source, i18nInfo.value, languages);
-
-    if (!selectedLanguage) {
-        if (callback) {
-            callback(new Error("Could not find desired language"));
-        }
-        return;
-    }
-
-    _mergeSelectedLanguage(destinationToAddLanguageTo, selectedLanguage);
-
-    if (callback) {
-        callback();
-    }
+module.exports.transformDestination = function (source, destinationToAddLanguageTo, acceptedLanguages, callback) {
+    return _transformDestination(source, destinationToAddLanguageTo, acceptedLanguages, null, callback);
 };

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "grunt": "^0.4.4",
     "grunt-cli": "^0.1.13",
     "grunt-mocha-test": "^0.10.0",
-    "should": "^3.2.0",
+    "should": "^10.0.0",
     "grunt-contrib-jshint": "^0.9.2"
   },
   "dependencies": {
-    "hoek": "^2.1.0"
+    "lodash": "^4.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "apply an i18n transform to a json object",
   "main": "index.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "coverage": "grunt coverage"
   },
   "repository": {
     "type": "git",
@@ -23,9 +24,11 @@
   "devDependencies": {
     "grunt": "^0.4.4",
     "grunt-cli": "^0.1.13",
+    "grunt-contrib-jshint": "^0.9.2",
+    "grunt-mocha-istanbul": "^5.0.1",
     "grunt-mocha-test": "^0.10.0",
-    "should": "^10.0.0",
-    "grunt-contrib-jshint": "^0.9.2"
+    "istanbul": "^0.4.4",
+    "should": "^10.0.0"
   },
   "dependencies": {
     "lodash": "^4.13.1"

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -689,7 +689,7 @@ describe('i18n tansformByFields tests', function () {
             };
         });
 
-        it('should not return optional fields if not present', function () {
+        it('should set optional fields if not present to null', function () {
             var result = i18n.transformByField(translations, [{
                 code: "it",
                 region: "IT",
@@ -704,7 +704,7 @@ describe('i18n tansformByFields tests', function () {
                 ]
             });
 
-            (result.translations.Area === undefined).should.be.true;
+            (result.translations.Area === null).should.be.true;
             (result.localization.Area === undefined).should.be.true;
         });
 
@@ -768,7 +768,7 @@ describe('i18n tansformByFields tests', function () {
                 ]
             });
 
-            (result.translations.PriceBand === undefined).should.be.true;
+            (result.translations.PriceBand === null).should.be.true;
             (result.localization.PriceBand === undefined).should.be.true;
         });
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,7 +1,7 @@
 var i18n = require('../lib/i18n-transform');
 should = require('should');
 
-describe('i18n tests', function () {
+describe('i18n transform tests', function () {
     it('should merge the fields for the specified language', function () {
         var result = i18n.transform({
             i18n: [
@@ -495,6 +495,7 @@ describe('i18n tests', function () {
         result.Name.should.eql('pip pip tally ho crumpets and tea');
     });
 
+
     it('should select the primary language', function () {
         var result = i18n.transform({
             i18n: [
@@ -555,5 +556,248 @@ describe('i18n tests', function () {
         );
 
         result.Language.IETF.should.eql("en-US");
+    });
+});
+
+describe('i18n tansformByFields tests', function () {
+
+    describe('when all requested locales are present', function () {
+        var translations = null;
+        beforeEach(function () {
+            translations = {
+                i18n: [
+                    {
+                        Name: "gonna drink some beer and shoot some stuff y'all",
+                        Description: "This is a description in US English",
+                        Language: {
+                            IETF: "en-US",
+                            Code: "en",
+                            Region: "US"
+                        }
+                    },
+                    {
+                        Name: "pip pip tally ho crumpets and tea",
+                        Description: "This is a description in GB English",
+                        Language: {
+                            IETF: "en-GB",
+                            Code: "en",
+                            Region: "GB"
+                        }
+                    }
+                ],
+                PrimaryLanguage: "en-US"
+            };
+        });
+
+        it('should return all required fields in the requested locale', function () {
+
+            var result = i18n.transformByField(translations, [{
+                code: "en",
+                region: "US",
+                quality: 1.0
+            }], {
+                required: [
+                    'Name',
+                    'Description'
+                ],
+            });
+
+            result.translations.Name.should.eql("gonna drink some beer and shoot some stuff y'all");
+            result.translations.Description.should.eql("This is a description in US English");
+            result.localization.Name.should.eql('en-US');
+            result.localization.Description.should.eql('en-US');
+        });
+
+        it('should fallback to primary locale when * is used', function () {
+            var result = i18n.transformByField(translations, [{
+                code: "*",
+            }], {
+                required: [
+                    'Name',
+                    'Description'
+                ],
+            });
+
+            result.translations.Name.should.eql('gonna drink some beer and shoot some stuff y\'all');
+            result.translations.Description.should.eql('This is a description in US English');
+
+            result.localization.Name.should.eql('en-US');
+            result.localization.Description.should.eql('en-US');
+
+        });
+
+        it('should fallback to primary locale when * is anywhere in the set', function () {
+            var result = i18n.transformByField(translations, [
+                { code: "es", region: "MX", quality: 1.0 },
+                { code: "*", quality: 0.8 },
+                { code: "fr", region: "CA", quality: 0.6 },
+                { code: "en", region: "GB", quality: 0.4 }],
+                {
+                    required: [
+                        'Name',
+                        'Description'
+                    ],
+                });
+
+            result.translations.Name.should.eql('gonna drink some beer and shoot some stuff y\'all');
+            result.translations.Description.should.eql('This is a description in US English');
+
+            result.localization.Name.should.eql('en-US');
+            result.localization.Description.should.eql('en-US');
+
+        });
+
+    });
+
+    describe('when translations are missing for fields', function () {
+        var translations = null;
+
+        beforeEach(function () {
+            translations = {
+                i18n: [
+                    {
+                        Name: "gonna drink some beer and shoot some stuff y'all",
+                        Description: "This is a description in US English",
+                        DressCode: "Smart Casual",
+                        PriceBand: 'Budget',
+                        Area: 'Orlando',
+                        Language: {
+                            IETF: "en-US",
+                            Code: "en",
+                            Region: "US"
+                        }
+                    },
+                    {
+                        Name: "pip pip tally ho crumpets and tea",
+                        Description: "This is a description in GB English",
+                        Language: {
+                            IETF: "en-GB",
+                            Code: "en",
+                            Region: "GB"
+                        }
+                    },
+                    {
+                        Name: 'Benvenuti in un mondo di cibo',
+                        Language: {
+                            IETF: "it-IT",
+                            Code: "it",
+                            Region: "IT"
+                        }
+                    }
+                ],
+                PrimaryLanguage: "en-US"
+            };
+        });
+
+        it('should not return optional fields if not present', function () {
+            var result = i18n.transformByField(translations, [{
+                code: "it",
+                region: "IT",
+                quality: 1.0
+            }], {
+                required: [
+                    'Name',
+                    'Description'
+                ],
+                optional: [
+                    'Area'
+                ]
+            });
+
+            (result.translations.Area === undefined).should.be.true;
+            (result.localization.Area === undefined).should.be.true;
+        });
+
+        it('should fallback to a specified secondary locale', function () {
+            var result = i18n.transformByField(translations, [{
+                code: "it",
+                region: "IT",
+                quality: 1.0
+            },
+            {
+                code: "en",
+                region: "US",
+                quality: 0.9
+            }], {
+                required: [
+                    'Name',
+                    'Description'
+                ],
+            });
+
+            result.translations.Name.should.eql('Benvenuti in un mondo di cibo');
+            result.translations.Description.should.eql('This is a description in US English');
+
+            result.localization.Name.should.eql('it-IT');
+            result.localization.Description.should.eql('en-US');
+        });
+
+        it('should fallback to primary locale for required field if locale not present', function () {
+            var result = i18n.transformByField(translations, [{
+                code: "es",
+                region: "ES",
+                quality: 1.0
+            }], {
+                required: [
+                    'Name',
+                    'Description'
+                ],
+                optional: [
+                    'PriceBand'
+                ]
+            });
+
+            result.translations.Name.should.eql('gonna drink some beer and shoot some stuff y\'all');
+            result.translations.Description.should.eql('This is a description in US English');
+
+            result.localization.Name.should.eql('en-US');
+            result.localization.Description.should.eql('en-US');
+
+            (result.translations.PriceBand == null).should.be.true;
+            (result.localization.PriceBand == null).should.be.true;
+        });
+
+        it('should not fallback to primary locale for optional field if not present', function () {
+            var result = i18n.transformByField(translations, [{
+                code: "it",
+                region: "IT",
+                quality: 1.0
+            }], {
+                optional: [
+                    'PriceBand'
+                ]
+            });
+
+            (result.translations.PriceBand === undefined).should.be.true;
+            (result.localization.PriceBand === undefined).should.be.true;
+        });
+
+        it('should match for accept-lang without region for an optional field', function () {
+            var result = i18n.transformByField(translations, [{
+                code: "en",
+                quality: 1.0
+            }], {
+                optional: [
+                    'DressCode'
+                ]
+            });
+
+            result.translations.DressCode.should.eql('Smart Casual');
+            result.localization.DressCode.should.eql('en-US');
+        });
+
+        it('should select primary language for partial accept-lang when multiply available', function () {
+            var result = i18n.transformByField(translations, [{
+                code: "en",
+                quality: 1.0
+            }], {
+                optional: [
+                    'Name'
+                ]
+            });
+
+            result.translations.Name.should.eql('gonna drink some beer and shoot some stuff y\'all');
+            result.localization.Name.should.eql('en-US');
+        });
     });
 });


### PR DESCRIPTION
### New methods transformByField & transformByFieldDestination 

This method now allows an array of fields to be supplied (optional & required) and each field will be evaluated independently against each i18n node. The rational behind this is that sparse i18n nodes could be supplied to the transform which don't contain all translations. As apposed to the current implantation which just matches against the i18n block and assume it has all translations present. 

### Optional Vs Required
If the accept-language is strict e.g. "ja-JP" and we have required fields such as "name" there could be a possibility where a "ja-JP" translation does not exist for "name". Therefore with required fields we fallback to the primary language. 

For optional fields we will simply omit the field if not match is found.

### Other Changes
- Added code coverage
- Updated should dependancy 
- Switched hoek for lodash (apply is more performant than merge)


### TODO
- [x] Updated Readme
