### PR TITLE
Primary language is now used if a supplied ISO 639-1 matches.

### DIFF
--- a/lib/i18n-transform.js
+++ b/lib/i18n-transform.js
@@ -1,18 +1,18 @@
 var hoek = require("hoek");
 
-var _getLanguageFromI18n = function(i18nObj) {
-        if (i18nObj.Language) {
-            return {
-                code: i18nObj.Language.Code,
-                region: i18nObj.Language.Region,
-                ietf: i18nObj.Language.IETF
-            };
-        }
+var _getLanguageFromI18n = function (i18nObj) {
+    if (i18nObj.Language) {
+        return {
+            code: i18nObj.Language.Code,
+            region: i18nObj.Language.Region,
+            ietf: i18nObj.Language.IETF
+        };
+    }
 
-        return null;
-    },
+    return null;
+},
 
-    _getI18n = function(source) {
+    _getI18n = function (source) {
         if (source.i18n) {
             return {
                 name: 'i18n',
@@ -28,7 +28,7 @@ var _getLanguageFromI18n = function(i18nObj) {
         return null;
     },
 
-    _extractPrimaryLanguage = function(r, i18nArray){
+    _extractPrimaryLanguage = function (r, i18nArray) {
         if (!r.PrimaryLanguage) {
             //just use whatever is available
             if (i18nArray[0]) {
@@ -40,7 +40,7 @@ var _getLanguageFromI18n = function(i18nObj) {
 
         var language = null;
 
-        i18nArray.forEach(function(l) {
+        i18nArray.forEach(function (l) {
             var i18nLanguage = _getLanguageFromI18n(l);
             if (i18nLanguage && i18nLanguage.ietf) {
                 if (i18nLanguage.ietf.toUpperCase() === r.PrimaryLanguage.toUpperCase()) {
@@ -52,50 +52,61 @@ var _getLanguageFromI18n = function(i18nObj) {
         return language;
     },
 
-    _extractPreferredLanguage = function(r, i18nArray, languages){
+    _shouldUsePrimaryLanguage = function (primaryLanguage, languageCode) {
+        return primaryLanguage &&
+            !languageCode.region &&
+            primaryLanguage.split('-')[0] === languageCode.code;
+    },
+
+    _extractPreferredLanguage = function (r, i18nArray, languages) {
         var language = null;
 
-        languages.forEach(function(l){
-            i18nArray.forEach(function(rl){
+        languages.forEach(function (l) {
+            i18nArray.forEach(function (rl) {
                 var i18nLanguage = _getLanguageFromI18n(rl);
-                if(l.code === "*"){
+
+                if (l.code === "*") {
                     language = language || l.code;
                 }
 
-                if(l.code.toUpperCase() === i18nLanguage.code.toUpperCase() &&
-                    ((l.region === undefined || i18nLanguage.region === undefined ) ||
-                    l.region.toUpperCase() === i18nLanguage.region.toUpperCase())) {
+                if (_shouldUsePrimaryLanguage(r.PrimaryLanguage, l)) {
+                    language = language || "*";
+                }
+
+                if (l.code.toUpperCase() === i18nLanguage.code.toUpperCase() &&
+                    ((l.region === undefined || i18nLanguage.region === undefined) ||
+                        l.region.toUpperCase() === i18nLanguage.region.toUpperCase())) {
                     language = language || rl;
                 }
             });
         });
 
-        if(language === "*"){
+        if (language === "*") {
             return _extractPrimaryLanguage(r, i18nArray);
         }
 
         return language;
     },
 
-    _mergeSelectedLanguage = function(destination, language){
-        if(!language){
+    _mergeSelectedLanguage = function (destination, language) {
+        if (!language) {
             return destination;
         }
         return hoek.merge(destination, language);
     },
 
-    _getSelectedLanguage = function(source, i18nArray, languages){
+    _getSelectedLanguage = function (source, i18nArray, languages) {
         // expects the language object from the request to be passed in:
         // [
         //   { code: 'en', region: 'US', quality: 1.0 },
         //   { code: 'en',               quality: 0.8 },
         //    ...
         // ]
-        if(!languages || languages.length === 0){
-            return  _extractPrimaryLanguage(source, i18nArray);
+        if (!languages || languages.length === 0) {
+            return _extractPrimaryLanguage(source, i18nArray);
         }
         else {
-            languages.sort(function(a, b){
+            languages.sort(function (a, b) {
                 return b.quality - a.quality;
             });
 
@@ -103,15 +114,15 @@ var _getLanguageFromI18n = function(i18nObj) {
         }
     };
 
-module.exports.transform = function(source, languages){
+module.exports.transform = function (source, languages) {
     var i18nInfo = _getI18n(source);
 
-    if(!i18nInfo){
+    if (!i18nInfo) {
         return source;
     }
 
     var selectedLanguage = _getSelectedLanguage(source, i18nInfo.value, languages);
-    if (!selectedLanguage){
+    if (!selectedLanguage) {
         return;
     }
 
@@ -120,10 +131,10 @@ module.exports.transform = function(source, languages){
     return result;
 };
 
-module.exports.transformDestination = function(source, destinationToAddLanguageTo, languages, callback){
+module.exports.transformDestination = function (source, destinationToAddLanguageTo, languages, callback) {
     var i18nInfo = _getI18n(source);
 
-    if(!i18nInfo){
+    if (!i18nInfo) {
         return source;
     }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,8 +1,8 @@
 var i18n = require('../lib/i18n-transform');
-    should = require('should');
+should = require('should');
 
-describe('i18n tests', function(){
-    it('should merge the fields for the specified language', function(){
+describe('i18n tests', function () {
+    it('should merge the fields for the specified language', function () {
         var result = i18n.transform({
             i18n: [
                 {
@@ -24,14 +24,14 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-US"
         }, [
-            { code: "en", region: "US", quality: 1.0 }
-        ]);
+                { code: "en", region: "US", quality: 1.0 }
+            ]);
 
         result.Name.should.eql("gonna drink some beer and shoot some stuff y'all");
         result.Language.IETF.should.eql("en-US");
     });
 
-    it('should allow us to use I18n instead of i18n for the international array', function(){
+    it('should allow us to use I18n instead of i18n for the international array', function () {
         var result = i18n.transform({
             I18n: [
                 {
@@ -53,46 +53,46 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-US"
         }, [
-            { code: "en", region: "US", quality: 1.0 }
-        ]);
+                { code: "en", region: "US", quality: 1.0 }
+            ]);
 
         result.Name.should.eql("gonna drink some beer and shoot some stuff y'all");
         result.Language.IETF.should.eql("en-US");
     });
 
-    it('should add the language fields to the destination when using transformDestination', function(){
-      var destinationObject = {};
-      i18n.transformDestination({
-        i18n: [
-          {
-            Name: "gonna drink some beer and shoot some stuff y'all",
-            Language: {
-              IETF: "en-US",
-              Code: "en",
-              Region: "US"
-            }
-          },
-          {
-            Name: "pip pip tally ho crumpets and tea",
-            Language: {
-              IETF: "en-GB",
-              Code: "en",
-              Region: "GB"
-            }
-          }
-        ],
-        PrimaryLanguage: "en-US"
-      },
-      destinationObject,
-      [
-        { code: "en", region: "US", quality: 1.0 }
-      ]);
+    it('should add the language fields to the destination when using transformDestination', function () {
+        var destinationObject = {};
+        i18n.transformDestination({
+            i18n: [
+                {
+                    Name: "gonna drink some beer and shoot some stuff y'all",
+                    Language: {
+                        IETF: "en-US",
+                        Code: "en",
+                        Region: "US"
+                    }
+                },
+                {
+                    Name: "pip pip tally ho crumpets and tea",
+                    Language: {
+                        IETF: "en-GB",
+                        Code: "en",
+                        Region: "GB"
+                    }
+                }
+            ],
+            PrimaryLanguage: "en-US"
+        },
+            destinationObject,
+            [
+                { code: "en", region: "US", quality: 1.0 }
+            ]);
 
-      destinationObject.Name.should.eql("gonna drink some beer and shoot some stuff y'all");
-      destinationObject.Language.IETF.should.eql("en-US");
+        destinationObject.Name.should.eql("gonna drink some beer and shoot some stuff y'all");
+        destinationObject.Language.IETF.should.eql("en-US");
     });
 
-    it('should preserve fields in the root of the document', function(){
+    it('should preserve fields in the root of the document', function () {
         var result = i18n.transform({
             DomainId: 123,
             i18n: [
@@ -115,15 +115,15 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-US"
         }, [
-            { code: "en", region: "US", quality: 1.0 }
-        ]);
+                { code: "en", region: "US", quality: 1.0 }
+            ]);
 
         result.DomainId.should.eql(123);
     });
 
-    it('should select the primary language when no language is specified', function(){
+    it('should select the primary language when no language is specified', function () {
         var result = i18n.transform({
-            i18n:[
+            i18n: [
                 {
                     Name: "gonna drink some beer and shoot some stuff y'all",
                     Language: {
@@ -148,7 +148,7 @@ describe('i18n tests', function(){
         result.Language.IETF.should.eql("en-US");
     });
 
-    it('should select the first available language based on the given set', function(){
+    it('should select the first available language based on the given set', function () {
         var result = i18n.transform({
             DomainId: 123,
             i18n: [
@@ -171,14 +171,14 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-US"
         }, [
-            { code: "es", region: "MX", quality: 1.0 },
-            { code: "en", region: "US", quality: 0.8 }
-        ]);
+                { code: "es", region: "MX", quality: 1.0 },
+                { code: "en", region: "US", quality: 0.8 }
+            ]);
 
         result.Language.IETF.should.eql("en-US");
     });
 
-    it('should select the primary language when a wildcard is specified', function(){
+    it('should select the primary language when a wildcard is specified', function () {
         var result = i18n.transform({
             DomainId: 123,
             i18n: [
@@ -201,15 +201,15 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-US"
         }, [
-            { code: "es", region: "MX", quality: 1.0 },
-            { code: "fr", region: "CA", quality: 0.8 },
-            { code: "*", quality: 0.4 }
-        ]);
+                { code: "es", region: "MX", quality: 1.0 },
+                { code: "fr", region: "CA", quality: 0.8 },
+                { code: "*", quality: 0.4 }
+            ]);
 
         result.Language.IETF.should.eql("en-US");
     });
 
-    it('should select the primary language when a wildcard is specified anywhere in the set', function(){
+    it('should select the primary language when a wildcard is specified anywhere in the set', function () {
         var result = i18n.transform({
             DomainId: 123,
             i18n: [
@@ -232,46 +232,16 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-US"
         }, [
-            { code: "es", region: "MX", quality: 1.0 },
-            { code: "*", quality: 0.8 },
-            { code: "fr", region: "CA", quality: 0.6 },
-            { code: "en", region: "GB", quality: 0.4 }
-        ]);
+                { code: "es", region: "MX", quality: 1.0 },
+                { code: "*", quality: 0.8 },
+                { code: "fr", region: "CA", quality: 0.6 },
+                { code: "en", region: "GB", quality: 0.4 }
+            ]);
 
         result.Language.IETF.should.eql("en-US");
     });
 
-    it('should select the first match when there are multiple matches', function(){
-        var result = i18n.transform({
-            DomainId: 123,
-            i18n: [
-                {
-                    Name: "pip pip tally ho crumpets and tea",
-                    Language: {
-                        IETF: "en-GB",
-                        Code: "en",
-                        Region: "GB"
-                    }
-                },
-                {
-                    Name: "gonna drink some beer and shoot some stuff y'all",
-                    Language: {
-                        IETF: "en-US",
-                        Code: "en",
-                        Region: "US"
-                    }
-                }
-            ],
-            PrimaryLanguage: "en-US"
-        }, [
-            { code: "en", region: "AU", quality: 1.0 },
-            { code: "en", quality: 0.8 }
-        ]);
-
-        result.Language.IETF.should.eql("en-GB");
-    });
-
-    it('should select the first match from a complex set', function(){
+    it('should select the first match from a complex set', function () {
         var result = i18n.transform({
             DomainId: 123,
             i18n: [
@@ -302,17 +272,17 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-US"
         }, [
-            { code: "de", region: "DE", quality: 1.0 },
-            { code: "fr",               quality: 0.8 },
-            { code: "en", region: "US", quality: 0.6 },
-            { code: "en",               quality: 0.4 },
-            { code: "*",                quality: 0.1 }
-        ]);
+                { code: "de", region: "DE", quality: 1.0 },
+                { code: "fr", quality: 0.8 },
+                { code: "en", region: "US", quality: 0.6 },
+                { code: "en", quality: 0.4 },
+                { code: "*", quality: 0.1 }
+            ]);
 
         result.Language.IETF.should.eql("fr-CA");
     });
 
-    it('should sort the language set based on quality', function(){
+    it('should sort the language set based on quality', function () {
         var result = i18n.transform({
             DomainId: 123,
             i18n: [
@@ -343,17 +313,17 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-US"
         }, [
-            { code: "en", region: "US", quality: 0.6 },
-            { code: "de", region: "DE", quality: 1.0 },
-            { code: "en",               quality: 0.4 },
-            { code: "*",                quality: 0.1 },
-            { code: "fr",               quality: 0.8 },
-        ]);
+                { code: "en", region: "US", quality: 0.6 },
+                { code: "de", region: "DE", quality: 1.0 },
+                { code: "en", quality: 0.4 },
+                { code: "*", quality: 0.1 },
+                { code: "fr", quality: 0.8 },
+            ]);
 
         result.Language.IETF.should.eql("fr-CA");
     });
 
-    it('should compare language codes in a case-insensitive manner', function(){
+    it('should compare language codes in a case-insensitive manner', function () {
         var result = i18n.transform({
             DomainId: 123,
             i18n: [
@@ -376,13 +346,13 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-GB"
         }, [
-            { code: "En", region: "us", quality: 1 }
-        ]);
+                { code: "En", region: "us", quality: 1 }
+            ]);
 
         result.Language.IETF.should.eql("en-US");
     });
 
-    it('should not break when region is undefined', function(){
+    it('should not break when region is undefined', function () {
         var result = i18n.transform({
             DomainId: 123,
             i18n: [
@@ -403,13 +373,13 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en"
         }, [
-            { code: "En", region: "US", quality: 1 }
-        ]);
+                { code: "En", region: "US", quality: 1 }
+            ]);
 
         result.Language.IETF.should.eql("en");
     });
 
-    it('should delete the i18n section', function(){
+    it('should delete the i18n section', function () {
         var result = i18n.transform({
             i18n: [
                 {
@@ -423,13 +393,13 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-US"
         }, [
-            { code: "en", region: "US", quality: 1.0 }
-        ]);
+                { code: "en", region: "US", quality: 1.0 }
+            ]);
 
         (result.i18n === undefined).should.eql(true);
     });
 
-    it('should delete the I18n section if thats what we found', function(){
+    it('should delete the I18n section if thats what we found', function () {
         var result = i18n.transform({
             I18n: [
                 {
@@ -443,24 +413,24 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-US"
         }, [
-            { code: "en", region: "US", quality: 1.0 }
-        ]);
+                { code: "en", region: "US", quality: 1.0 }
+            ]);
 
         (result.I18n === undefined).should.eql(true);
     });
 
-    it('should not break when source.i18n is undefined', function(){
+    it('should not break when source.i18n is undefined', function () {
         var result = i18n.transform({
             AField: 123,
             PrimaryLanguage: "en"
         }, [
-            { code: "En", region: "US", quality: 1 }
-        ]);
+                { code: "En", region: "US", quality: 1 }
+            ]);
 
         result.AField.should.eql(123);
     });
 
-    it('should return null if preferred language does not exist', function(){
+    it('should return null if preferred language does not exist', function () {
         var result = i18n.transform({
             DomainId: 123,
             i18n: [
@@ -475,37 +445,37 @@ describe('i18n tests', function(){
             ],
             PrimaryLanguage: "en-GB"
         }, [
-            { code: "de", region: "DE", quality: 1.0 }
-        ]);
+                { code: "de", region: "DE", quality: 1.0 }
+            ]);
 
         (result == null).should.be.true;
     });
 
 
-    it('transformDestination should give an error if language does not exist', function(){
+    it('transformDestination should give an error if language does not exist', function () {
         var error = null;
-            var result = i18n.transformDestination({
-                DomainId: 123,
-                i18n: [
-                    {
-                        Name: "pip pip tally ho crumpets and tea",
-                        Language: {
-                            IETF: "en-GB",
-                            Code: "en",
-                            Region: "GB"
-                        }
-                    },
-                ],
-                PrimaryLanguage: "en-GB"
-            }, {}, [
+        var result = i18n.transformDestination({
+            DomainId: 123,
+            i18n: [
+                {
+                    Name: "pip pip tally ho crumpets and tea",
+                    Language: {
+                        IETF: "en-GB",
+                        Code: "en",
+                        Region: "GB"
+                    }
+                },
+            ],
+            PrimaryLanguage: "en-GB"
+        }, {}, [
                 { code: "de", region: "DE", quality: 1.0 }
-            ], function(err){
+            ], function (err) {
                 error = err;
             });
         (error == null).should.be.false;
     });
 
-    it('if we ask for * without a primary language then just use whatever comes first', function(){
+    it('if we ask for * without a primary language then just use whatever comes first', function () {
         var result = i18n.transform({
             DomainId: 123,
             i18n: [
@@ -519,9 +489,71 @@ describe('i18n tests', function(){
                 },
             ]
         }, [
-            { code: "*", quality: 1.0 }
-        ]);
+                { code: "*", quality: 1.0 }
+            ]);
 
         result.Name.should.eql('pip pip tally ho crumpets and tea');
+    });
+
+    it('should select the primary language', function () {
+        var result = i18n.transform({
+            i18n: [
+                {
+                    Name: "[en-US] Name",
+                    Language: {
+                        IETF: "en-US",
+                        Code: "en",
+                        Region: "US"
+                    }
+                },
+                {
+                    Name: "[en-GB] Name",
+                    Language: {
+                        IETF: "en-GB",
+                        Code: "en",
+                        Region: "GB"
+                    }
+                }
+            ],
+            PrimaryLanguage: "en-GB"
+        }, [
+                { code: "de", region: "DE", quality: 1.0 },
+                { code: "de", region: undefined, quality: 1.0 },
+                { code: "en", region: undefined, quality: 1.0 }
+            ]
+        );
+
+        result.Language.IETF.should.eql("en-GB");
+    });
+
+    it('shouldn\'t select the primary language', function () {
+        var result = i18n.transform({
+            i18n: [
+                {
+                    Name: "[en-US] Name",
+                    Language: {
+                        IETF: "en-US",
+                        Code: "en",
+                        Region: "US"
+                    }
+                },
+                {
+                    Name: "[en-GB] Name",
+                    Language: {
+                        IETF: "en-GB",
+                        Code: "en",
+                        Region: "GB"
+                    }
+                }
+            ],
+            PrimaryLanguage: "en-GB"
+        }, [
+                { code: "de", region: "DE", quality: 1.0 },
+                { code: "de", region: undefined, quality: 1.0 },
+                { code: "en", region: 'US', quality: 1.0 }
+            ]
+        );
+
+        result.Language.IETF.should.eql("en-US");
     });
 });


### PR DESCRIPTION
Fixes issue https://github.com/opentable/i18n-transform/issues/6.

When ISO 639-1 (2 letter code) are evaluated we now check against the primary language to see if we have a partial match e.g. en = en-GB, de = en-DB. If we get a match then we will use the primary language. 

- Removed conflicting test case that just selected the first item in the list.
 