### PR TITLE
2.1.1 - When the source field is null it is now not set.

### DIFF
--- a/lib/i18n-transform.js
+++ b/lib/i18n-transform.js
@@ -112,7 +112,7 @@ var _getLanguageFromI18n = function (i18nObj) {
         _.each(fields, function (field) {
             _.each(mappedTranslations, function (translations) {
 
-                if (!_.isUndefined(translations[field])) {
+                if (!_.isEmpty(translations[field])) {
                     results.translations[field] = translations[field];
                     results.localization[field] = translations.Language.IETF;
                     return false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-transform",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "apply an i18n transform to a json object",
   "main": "index.js",
   "scripts": {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -633,11 +633,11 @@ describe('i18n tansformByFields tests', function () {
                 { code: "fr", region: "CA", quality: 0.6 },
                 { code: "en", region: "GB", quality: 0.4 }],
                 {
-                    required: [
-                        'Name',
-                        'Description'
-                    ],
-                });
+                required: [
+                    'Name',
+                    'Description'
+                ],
+            });
 
             result.translations.Name.should.eql('gonna drink some beer and shoot some stuff y\'all');
             result.translations.Description.should.eql('This is a description in US English');
@@ -678,6 +678,7 @@ describe('i18n tansformByFields tests', function () {
                     },
                     {
                         Name: 'Benvenuti in un mondo di cibo',
+                        Description: null,
                         Language: {
                             IETF: "it-IT",
                             Code: "it",
@@ -809,6 +810,21 @@ describe('i18n tansformByFields tests', function () {
 
             result.translations.Name.should.eql('gonna drink some beer and shoot some stuff y\'all');
             result.localization.Name.should.eql('en-US');
+        });
+
+        it('should not set localization for field when source property is null', function () {
+            var result = i18n.transformByField(translations, [{
+                code: "it",
+                region: "IT",
+                quality: 1.0
+            }], {
+                optional: [
+                    'Description'
+                ]
+            });
+
+            (result.translations.Description === null).should.be.true;
+            (result.localization.Description === undefined).should.be.true;
         });
     });
 });


### PR DESCRIPTION
For transformByFields variants the localization object was have the field set even though the source was null. This PR now excluded both null or undefined. 